### PR TITLE
修复用户组保护

### DIFF
--- a/Application/Admin/Model/MemberModel.class.php
+++ b/Application/Admin/Model/MemberModel.class.php
@@ -11,7 +11,7 @@ class MemberModel extends Model{
         array('username','','用户名已存在！',0,'unique',self::MODEL_BOTH), // 在新增的时候验证name字段是否唯一
         array('email','','邮箱已存在！',0,'unique',self::MODEL_BOTH), // 在新增的时候验证name字段是否唯一
         array('staus',array(0,1),'请勿恶意修改字段',3,'in'), // 当值不为空的时候判断是否在一个范围内
-        array('type',array(1,2),'请勿恶意修改字段',3,'in'), // 当值不为空的时候判断是否在一个范围内
+        array('type',array(1,2,3,4),'请勿恶意修改字段',3,'in'), // 当值不为空的时候判断是否在一个范围内
     );
 
     protected $_auto = array(


### PR DESCRIPTION
\Application\Admin\Model\MemberModel.class.php...Line14处的
 array('type',array(1,2),'请勿恶意修改字段',3,'in'),
 应改为
  array('type',array(1,2,3,4),'请勿恶意修改字段',3,'in'),
以使admin.php?m=admin&c=member&a=update&id=1(创建/编辑前台用户)中后2种用户组变为可用